### PR TITLE
Fix libarchive detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ project(archive_cpp_wrapper)
 
 set(CMAKE_CXX_STANDARD 11)
 
-find_package(LibArchive)
+find_package(LibArchive REQUIRED)
 if(NOT TARGET LibArchive::LibArchive)
   add_library(LibArchive::LibArchive INTERFACE IMPORTED GLOBAL)
   target_include_directories(LibArchive::LibArchive INTERFACE ${LibArchive_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,11 @@ project(archive_cpp_wrapper)
 set(CMAKE_CXX_STANDARD 11)
 
 find_package(LibArchive)
-add_library(LibArchive::LibArchive INTERFACE IMPORTED GLOBAL)
-target_include_directories(LibArchive::LibArchive INTERFACE ${LibArchive_INCLUDE_DIRS})
-target_link_libraries(LibArchive::LibArchive INTERFACE ${LibArchive_LIBRARIES})
-
+if(NOT TARGET LibArchive::LibArchive)
+  add_library(LibArchive::LibArchive INTERFACE IMPORTED GLOBAL)
+  target_include_directories(LibArchive::LibArchive INTERFACE ${LibArchive_INCLUDE_DIRS})
+  target_link_libraries(LibArchive::LibArchive INTERFACE ${LibArchive_LIBRARIES})
+endif()
 
 file(GLOB headers "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp")
 file(GLOB template_implementations "${CMAKE_CURRENT_SOURCE_DIR}/*.ipp")


### PR DESCRIPTION
This PR  fixes a problem with recent libarchive, as its cmake module uses targets now.